### PR TITLE
Fixed laminas component installer setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         }
     ],
     "extra": {
-        "zf": {
-            "module": "ZfrCors"
+        "laminas": {
+            "module": "LmcCors"
         }
     },
     "require": {


### PR DESCRIPTION
when I run composer require then https://github.com/laminas/laminas-component-installer does this

```
...
  - Installing laminas-commons/lmc-cors (v1.0.0): Loading from cache

  Please select which config file you wish to inject 'ZfrCors' into:
  [0] Do not inject
  [1] config/modules.config.php
  [2] config/development.config.php.dist
  Make your selection (default is 1):
...
```